### PR TITLE
Finalised logic for filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,6 +1710,11 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"dependencies": {
 		"@fortawesome/free-solid-svg-icons": "^6.1.1",
 		"@mapbox/mapbox-gl-geocoder": "^5.0.0",
+		"lodash": "^4.17.21",
 		"mapbox-gl": "^2.7.1",
 		"sugarss": "^4.0.1",
 		"svelte-fa": "^2.4.0"

--- a/src/components/FilterResults.svelte
+++ b/src/components/FilterResults.svelte
@@ -5,6 +5,11 @@
 	import Fa from 'svelte-fa/src/fa.svelte';
 	import { faArrowRight } from '@fortawesome/free-solid-svg-icons/index.es';
 
+	// Utils
+	import { titleCase } from '@utils';
+
+	export let results;
+
 	const dispatch = createEventDispatcher();
 
 	const handleCloseResults = () => {
@@ -14,6 +19,15 @@
 	const viewMap = () => {
 		dispatch('viewMap');
 	};
+
+	const handleFlyFromResults = (e, x, y) => {
+		dispatch('flyFromResults', {
+			x,
+			y
+		});
+	};
+
+	$: isResultsEmpty = Object.keys(results).length === 0;
 </script>
 
 <div class="max-w-full text-2xl lg:text-base flex justify-between items-center">
@@ -26,4 +40,22 @@
 	>
 		View Map
 	</p>
+</div>
+<div class="my-8">
+	{#if !isResultsEmpty}
+		{#each Object.entries(results) as [sector, crags]}
+			<h4 class="text-lg">{titleCase(sector)}</h4>
+			{#each crags as crag}
+				<div
+					class="min-w-full hover:bg-light-blue cursor-pointer"
+					on:click={(e) => handleFlyFromResults(e, crag.x, crag.y)}
+				>
+					<p class="p-2 m-0 font-normal text-base">{titleCase(crag.name)}</p>
+				</div>
+			{/each}
+			<hr />
+		{/each}
+	{:else}
+		<h3>No crag match your search</h3>
+	{/if}
 </div>

--- a/src/components/Filters.svelte
+++ b/src/components/Filters.svelte
@@ -1,4 +1,7 @@
 <script>
+	// External libraries
+	import { isEqual } from 'lodash';
+
 	// Font awesome
 	import Fa from 'svelte-fa/src/fa.svelte';
 	import { faArrowLeft, faSun, faMoon } from '@fortawesome/free-solid-svg-icons/index.es';
@@ -16,7 +19,10 @@
 	import FilterResults from '@components/FilterResults.svelte';
 
 	// Utils
-	import { formatFilterFormData } from '@utils';
+	import { formatFilterFormData, digestFormData } from '@utils';
+
+	// Stores
+	import { falesie } from '@stores';
 
 	const dispatch = createEventDispatcher();
 
@@ -37,6 +43,8 @@
 	let allSun = false;
 	let allShadow = false;
 	let appear = false;
+	let filterHistory = {};
+	let filteredData = {};
 
 	let submitCounter = 0;
 
@@ -44,12 +52,18 @@
 
 	const handleSubmit = (e) => {
 		e.preventDefault();
-		console.log('submit');
+
 		submitCounter++;
 
 		let formData = new FormData(filterForm);
-		let data = formatFilterFormData(formData);
-		// console.log(data);
+		let filters = formatFilterFormData(formData);
+
+		// If the filters are identical to the one saved in store --> return
+		let isSameFilter = isEqual(filters, filterHistory);
+		if (!isSameFilter) {
+			filterHistory = filters;
+			filteredData = digestFormData($falesie, filters);
+		}
 		appear = true;
 	};
 
@@ -71,6 +85,8 @@
 			transition:fly={{ x: 500, duration: 200 }}
 		>
 			<FilterResults
+				results={filteredData}
+				on:flyFromResults
 				on:closeFilterResults={() => (appear = false)}
 				on:viewMap={(e) => {
 					handleClose(e, true);

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -132,6 +132,20 @@
 		});
 	};
 
+	const flyFromResults = (map, x, y) => {
+		map.setBearing(0);
+		map.flyTo({
+			center: [x, y],
+			speed: 1,
+			curve: 1,
+			zoom: 16
+		});
+
+		if (window.innerWidth < 1024) {
+			filterActive = false;
+		}
+	};
+
 	// TODO
 	const forwardGeocoder = (query) => {
 		const matchingFeatures = [];
@@ -328,7 +342,11 @@
 	}}
 />
 <Popup {roadName} {featureName} {featureLink} {show} {x} {y} handleClose={closePopup} />
-<Filters active={filterActive} on:closeFilters={() => (filterActive = false)} />
+<Filters
+	active={filterActive}
+	on:closeFilters={() => (filterActive = false)}
+	on:flyFromResults={(e) => flyFromResults(map, e.detail.x, e.detail.y)}
+/>
 
 <style>
 	.active {

--- a/src/components/SunlightProgressBar.svelte
+++ b/src/components/SunlightProgressBar.svelte
@@ -54,8 +54,8 @@
 
 	export const resetSlider = (e) => {
 		setTimeout(() => {
-			setLowerValue(9);
-			setUpperValue(14);
+			setLowerValue(7);
+			setUpperValue(19);
 
 			upperValue = upperSlider.value;
 			lowerValue = lowerSlider.value;
@@ -84,7 +84,7 @@
 			min="0"
 			max={sliderMaxValue}
 			step="1"
-			value="9"
+			value="7"
 			name="lower-suntime"
 			class="absolute min-w-full top-0 h-4 mx-auto appearance-none bg-transparent pointer-events-none"
 			disabled={!enabled}
@@ -97,7 +97,7 @@
 			min="0"
 			max={sliderMaxValue}
 			step="1"
-			value="14"
+			value="19"
 			name="upper-suntime"
 			class="absolute min-w-full top-0 h-4 mx-auto appearance-none bg-transparent pointer-events-none"
 			disabled={!enabled}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,18 @@
+// Global variables
+const AZIMUTH = {
+	north: 'North',
+	'north-east': 'Northeast',
+	east: 'East',
+	'south-east': 'Southeast',
+	south: 'South',
+	'south-west': 'Southwest',
+	west: 'West',
+	'north-west': 'Northwest'
+};
+
+const MIN_HOUR_OF_SUNLIGHT = 8;
+const MAX_HOUR_OF_SUNLIGHT = 16;
+
 export const parseTimeInterval = (interval) => {
 	if (interval === '-') return [];
 	return interval.split('-').map((v) => parseInt(v));
@@ -52,4 +67,221 @@ export const formatFilterFormData = (data) => {
 
 export const getSectorOptions = (sectors) => {
 	return sectors.map((sector) => sector.properties.Settore.toLowerCase());
+};
+
+const getAllowedExposures = (exposures) => {
+	let allowedExposures = [];
+	for (const [key, value] of Object.entries(exposures)) {
+		if (value) {
+			allowedExposures.push(AZIMUTH[key]);
+		}
+	}
+
+	return allowedExposures;
+};
+
+const formatHoursOfSunlight = (interval) => {
+	return interval.split('-').map((hour) => parseInt(hour));
+};
+
+const formatResults = (results) => {
+	// Return a formatted version from results
+	// to be displayed and used in the filterResults component
+	let properties;
+	let wall;
+	let sector;
+	let output = {};
+
+	// TODO Special case -> call function for similar results
+	if (results.length === 0) return {};
+
+	for (let crag of results) {
+		properties = crag.properties;
+		wall = {
+			name: properties.falesia,
+			x: properties.falesia_x,
+			y: properties.falesia_y
+		};
+		sector = properties.Settore.toLowerCase();
+
+		if (sector === '-') {
+			sector = properties.falesia;
+		}
+
+		if (output[sector]) {
+			output[sector].push(wall);
+		} else {
+			output[sector] = [wall];
+		}
+	}
+
+	return output;
+};
+
+const cleanResults = (results) => {
+	// Remove duplicates
+	let output = [];
+	let memory = [];
+
+	for (let record of results) {
+		if (memory.includes(record.id)) continue;
+		memory.push(record.id);
+		output.push(record);
+	}
+
+	return output;
+};
+
+const filterByArea = (area, data) => {
+	let properties;
+	let sector;
+	let results = [];
+
+	for (let crag of data) {
+		properties = crag.properties;
+		sector = properties.Settore === '-' ? properties.falesia : properties.Settore;
+
+		if (sector.toLowerCase() === area.toLowerCase() || area === 'all-sectors') {
+			results.push(crag);
+		}
+	}
+
+	return results;
+};
+
+const filterByExposure = (exposure, data) => {
+	let properties;
+	let results = [];
+
+	let allowedExposures = getAllowedExposures(exposure);
+
+	if (allowedExposures.length === 0) return data;
+
+	for (let crag of data) {
+		properties = crag.properties;
+		if (allowedExposures.includes(properties.azimut)) {
+			results.push(crag);
+		}
+	}
+
+	return results;
+};
+
+const filterBySunOptions = (options, hours, period, data) => {
+	// Depending on the options the min and max hours are selected
+
+	let properties;
+	let results = [];
+
+	let autumnResults = [];
+	let winterResults = [];
+	let springResults = [];
+	let summerResults = [];
+
+	// Active period in filter
+	let autumn = period.autumn;
+	let winter = period.winter;
+	let spring = period.spring;
+	let summer = period.summer;
+
+	let minHour, maxHour;
+
+	if (options === 'all-day-sun') {
+		[minHour, maxHour] = [MIN_HOUR_OF_SUNLIGHT, MAX_HOUR_OF_SUNLIGHT];
+	} else if (options === 'all-day-shadow') {
+		[minHour, maxHour] = [NaN, NaN];
+	} else {
+		minHour = hours.min;
+		maxHour = hours.max;
+	}
+
+	for (let crag of data) {
+		properties = crag.properties;
+		// Filter on all sun
+		let [minAutumn, maxAutumn] = formatHoursOfSunlight(properties.fall);
+		let [minWinter, maxWinter] = formatHoursOfSunlight(properties.winter);
+		let [minSpring, maxSpring] = formatHoursOfSunlight(properties.spring);
+		let [minSummer, maxSummer] = formatHoursOfSunlight(properties.summr);
+
+		// When all-day-sun I don't consider the interval but the time delta
+		// I want crags with gte 8h of sun
+		if (options === 'all-day-sun') {
+			if (maxAutumn - minAutumn >= maxHour - minHour && !isNaN(minAutumn)) {
+				autumnResults.push(crag);
+			}
+
+			if (maxWinter - minWinter >= maxHour - minHour && !isNaN(minWinter)) {
+				winterResults.push(crag);
+			}
+
+			if (maxSpring - minSpring >= maxHour - minHour && !isNaN(minSpring)) {
+				springResults.push(crag);
+			}
+
+			if (maxSummer - minSummer >= maxHour - minHour && !isNaN(minSummer)) {
+				summerResults.push(crag);
+			}
+		} else {
+			// Otherwise I consider the time interval
+			// Inclusive interval per season
+			if ((minAutumn >= minHour && maxAutumn <= maxHour) || (isNaN(minAutumn) && isNaN(minHour))) {
+				autumnResults.push(crag);
+			}
+
+			if ((minWinter >= minHour && maxWinter <= maxHour) || (isNaN(minWinter) && isNaN(minHour))) {
+				winterResults.push(crag);
+			}
+
+			if ((minSpring >= minHour && maxSpring <= maxHour) || (isNaN(minSpring) && isNaN(minHour))) {
+				springResults.push(crag);
+			}
+
+			if ((minSummer >= minHour && maxSummer <= maxHour) || (isNaN(minSummer) && isNaN(minHour))) {
+				summerResults.push(crag);
+			}
+		}
+	}
+
+	// If all the options are false then return all seasons
+	if (!autumn && !winter && !spring && !summer) {
+		results = [...autumnResults, ...winterResults, ...springResults, ...summerResults];
+	}
+
+	// If there is one or more options checked
+	if (autumn) {
+		results = [...results, ...autumnResults];
+	}
+
+	if (winter) {
+		results = [...results, ...winterResults];
+	}
+
+	if (spring) {
+		results = [...results, ...springResults];
+	}
+
+	if (summer) {
+		results = [...results, ...summerResults];
+	}
+
+	return cleanResults(results);
+};
+
+export const digestFormData = (data, filters) => {
+	let results = data;
+
+	// Colinder filter model
+	// 1. Sector
+	results = filterByArea(filters.area, results);
+
+	// 2. Exposure
+	results = filterByExposure(filters.exposure, results);
+
+	// 3. Sunlight
+	results = filterBySunOptions(filters.sunOptions, filters.hoursOfDay, filters.timeOfyear, results);
+
+	// Formatting to get an object with key[sector]: value[Array<crags>]
+	results = formatResults(results);
+	// console.log(results);
+	return results;
 };


### PR DESCRIPTION
Added methods for filtering based upon:
* Area or Sector. If the sector is not present, the name of the crag will be used
* Exposure: Based on the azimuth in the data, multiple selections supported
* Hours of sunlight: if the options are selected `all-day-sun` uses the time delta set at 8 or more hours. the `all-day-shadow` looks for places where the time is set as -. If no options are selected the time is used, in this case, the interval is inclusive and per time period. If a period is not specified all will be used as filters, if 1 or more are specified those will be used instead 